### PR TITLE
switched the order of the GrazeClient pipe to provide the ConfigProvider after the client layer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,8 @@ export class GrazeService {
     const provider = ConfigProvider.fromMap(envMap);
     const layer = Layer.setConfigProvider(provider);
     const make = setup.pipe(
-      Effect.provide(layer),
-      Effect.provide(GrazeClient.Default)
+      Effect.provide(GrazeClient.Default),
+      Effect.provide(layer)
     );
     const api = Effect.runSync(make);
     this.getFeed = api.getFeed;


### PR DESCRIPTION
i was finding that the API was requiring environment variables to be present for GRAZE_API_URL, GRAZE_COOKIE and GRAZE_USER_ID. with this change the environment vars don't need to be there and the API uses the values that are provided to the GrazeService constructor